### PR TITLE
Fix animation glitch when re-rendering component before animation completes

### DIFF
--- a/packages/react-anime/package.json
+++ b/packages/react-anime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-anime",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "(ﾉ´ヮ´)ﾉ*:･ﾟ✧ A super easy animation library for React.",
   "main": "dist/react-anime.js",
   "typings": "dist/react-anime.d.ts",

--- a/packages/react-anime/src/react-anime.js
+++ b/packages/react-anime/src/react-anime.js
@@ -59,6 +59,7 @@ export class Anime extends Component {
 
     let animeProps = { targets: this.targets, ...this.props };
 
+    anime.remove(this.targets);
     delete animeProps.children;
 
     if (typeof this.anime === undefined)

--- a/packages/react-anime/src/react-anime.js
+++ b/packages/react-anime/src/react-anime.js
@@ -52,12 +52,12 @@ export class Anime extends Component {
       next: !childrenWereRemoved ? difChildren : this.children.next
     };
 
-    this.createAnime();
+    this.createAnime(nextProps);
   }
 
-  createAnime = (props: AnimeProps) => {
+  createAnime = (props = this.props) => {
 
-    let animeProps = { targets: this.targets, ...this.props };
+    let animeProps = { targets: this.targets, ...props };
 
     anime.remove(this.targets);
     delete animeProps.children;


### PR DESCRIPTION
In animejs, you are suppose to remove the animation listener from your target elements if you toggle another animation on your targets before the current one has finished:
https://github.com/juliangarnier/anime#animeremovetarget

I created a codepen and if you toggle the button multiple times you will see the glitch:
https://codepen.io/ekeric13/pen/PKMqbm

![glitch](https://user-images.githubusercontent.com/6489651/30235595-df9a5698-94be-11e7-83ea-c25eef59e4a5.gif)


Simply removing the previous target before creating a new anime instance fixes this:
https://github.com/ekeric13/react-anime/blob/25132c01839eef1805a66874f40f19058df616b3/packages/react-anime/src/react-anime.js#L62

When I went to test this though, the first time i clicked on the button nothing happened, and then after that all the animations were doing the previous one.
It seems that the `createAnime` function isn't getting the latest props when called within `componentWillReceiveProps`.
I am not familiar with typescript nor the build process being used so maybe I was building the file incorrectly... but I am not sure how this repo is working in it's current state because of this issue.

Having a react wrapper around animejs is great. Would appreciate it to get these issues fixed and a new version published on npm.